### PR TITLE
Add DiyHue Room Assigner AppDaemon script

### DIFF
--- a/DiyHueRoomAssigner/README.md
+++ b/DiyHueRoomAssigner/README.md
@@ -1,0 +1,18 @@
+# DiyHue Room Assigner (AppDaemon)
+
+This AppDaemon app writes a `customize.yaml` file that assigns each light entity a
+`diyhue_room` attribute based on the entity's Home Assistant area. Use this
+file with diyHue to import your lights with the correct room names.
+
+## Usage
+1. Install the app into your AppDaemon `apps` directory.
+2. Configure it in `apps.yaml`:
+
+```yaml
+room_assigner:
+  module: diyhue_room_assigner
+  class: DiyHueRoomAssigner
+```
+
+3. Restart AppDaemon. The generated `customize.yaml` will be placed in your
+Home Assistant config folder.

--- a/DiyHueRoomAssigner/diyhue_room_assigner.py
+++ b/DiyHueRoomAssigner/diyhue_room_assigner.py
@@ -1,0 +1,40 @@
+import os
+import yaml
+import appdaemon.plugins.hass.hassapi as hass
+
+class DiyHueRoomAssigner(hass.Hass):
+    """Assigns each light entity a diyhue_room attribute based on its area."""
+
+    def initialize(self):
+        # Collect all light entities
+        states = self.get_state()
+        lights = {
+            entity_id: data
+            for entity_id, data in states.items()
+            if entity_id.startswith("light.")
+        }
+
+        # Get all area IDs
+        area_ids = self.areas()
+
+        # Build mapping of area_id -> area_name
+        areas = {aid: self.area_name(aid) for aid in area_ids}
+
+        customize = {}
+        for entity_id, state in lights.items():
+            aid = state.get("attributes", {}).get("area_id")
+            if aid and aid in areas:
+                customize[entity_id] = {"diyhue_room": areas[aid]}
+
+        # Determine path to Home Assistant customize.yaml
+        config_dir = str(self.config_dir)
+        out_path = os.path.join(os.path.dirname(config_dir), "customize.yaml")
+
+        try:
+            with open(out_path, "w", encoding="utf-8") as f:
+                yaml.dump(customize, f, allow_unicode=True)
+            self.log(
+                f"Erzeugt customize.yaml mit {len(customize)} Einträgen unter {out_path}"
+            )
+        except Exception as err:
+            self.error(f"Fehler beim Schreiben von customize.yaml: {err}")


### PR DESCRIPTION
## Summary
- add appdaemon app that assigns `diyhue_room` based on HA area
- provide basic usage instructions

## Testing
- `python3 -m py_compile DiyHueRoomAssigner/diyhue_room_assigner.py`


------
https://chatgpt.com/codex/tasks/task_e_688a80deb570832dae9657de6fb2697c