### PR TITLE
Translate DiyHue room assigner logs

### DIFF
--- a/DiyHueRoomAssigner/README.md
+++ b/DiyHueRoomAssigner/README.md
@@ -1,0 +1,20 @@
+# DiyHue Room Assigner (AppDaemon)
+
+This AppDaemon app writes a `customize.yaml` file that assigns each light entity a
+`diyhue_room` attribute based on the entity's Home Assistant area. Use this
+file with diyHue to import your lights with the correct room names.
+
+## Usage
+1. Install the app into your AppDaemon `apps` directory.
+2. Configure it in `apps.yaml`:
+
+```yaml
+room_assigner:
+  module: diyhue_room_assigner
+  class: DiyHueRoomAssigner
+```
+
+3. Restart AppDaemon. The generated `customize.yaml` will be placed in your
+Home Assistant config folder (the same folder that contains `configuration.yaml`).
+
+If a light entity does not belong to an area it will be skipped.

--- a/DiyHueRoomAssigner/diyhue_room_assigner.py
+++ b/DiyHueRoomAssigner/diyhue_room_assigner.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+import yaml
+import appdaemon.plugins.hass.hassapi as hass
+
+class DiyHueRoomAssigner(hass.Hass):
+    """Assigns each light entity a diyhue_room attribute based on its area."""
+
+    def initialize(self):
+        # Collect all light entities only
+        lights = self.get_state("light") or {}
+
+        # Build customize mapping using area names looked up via entity_id
+        customize = {}
+        for entity_id in lights:
+            area = self.area_name(entity_id)
+            if area:
+                customize[entity_id] = {"diyhue_room": area}
+
+        # Determine path to Home Assistant customize.yaml
+        out_path = Path(self.config_dir).parent / "customize.yaml"
+
+        try:
+            with open(out_path, "w", encoding="utf-8") as f:
+                yaml.safe_dump(customize, f, allow_unicode=True)
+            self.log(
+                f"Generated customize.yaml with {len(customize)} entries at {out_path}"
+            )
+        except Exception as err:
+            self.error(f"Error writing customize.yaml: {err}")


### PR DESCRIPTION
## Summary
- make the DiyHue Room Assigner app's log messages use English

## Testing
- `python3 -m py_compile DiyHueRoomAssigner/diyhue_room_assigner.py`


------
https://chatgpt.com/codex/tasks/task_e_688a80deb570832dae9657de6fb2697c