### PR TITLE
Fix customize path

### DIFF
--- a/DiyHueRoomAssigner/diyhue_room_assigner.py
+++ b/DiyHueRoomAssigner/diyhue_room_assigner.py
@@ -6,24 +6,43 @@ class DiyHueRoomAssigner(hass.Hass):
     """Assigns each light entity a diyhue_room attribute based on its area."""
 
     def initialize(self):
-        # Collect all light entities only
+        # Collect all light entities and their state
         lights = self.get_state("light") or {}
 
-        # Build customize mapping using area names looked up via entity_id
+        # Build customize mapping by resolving the area_id attribute of each
+        # light to an area name. ``self.area_name`` expects an ``area_id`` and
+        # returns the matching name.
         customize = {}
-        for entity_id in lights:
-            area = self.area_name(entity_id)
-            if area:
-                customize[entity_id] = {"diyhue_room": area}
+        for entity_id, state in lights.items():
+            aid = state.get("attributes", {}).get("area_id")
+            if aid:
+                area = self.area_name(aid)
+                if area:
+                    customize[entity_id] = {"diyhue_room": area}
 
-        # Determine path to Home Assistant customize.yaml
-        out_path = Path(self.config_dir).parent / "customize.yaml"
+        # Determine path to Home Assistant ``customize.yaml``.  Depending on
+        # the AppDaemon setup ``self.config_dir`` may either point directly to
+        # the Home Assistant config directory (e.g. ``/config``) or to a
+        # subdirectory like ``/config/appdaemon``.  To ensure the file ends up
+        # beside ``configuration.yaml`` we strip a trailing ``appdaemon`` if
+        # present.
+        ha_config = Path(self.config_dir)
+        if ha_config.name == "appdaemon":
+            ha_config = ha_config.parent
+        out_path = ha_config / "customize.yaml"
 
         try:
             with open(out_path, "w", encoding="utf-8") as f:
-                yaml.safe_dump(customize, f, allow_unicode=True)
+                yaml.safe_dump(
+                    customize,
+                    f,
+                    allow_unicode=True,
+                    default_flow_style=False,
+                    sort_keys=False,
+                )
             self.log(
-                f"Generated customize.yaml with {len(customize)} entries at {out_path}"
+                "Generated customize.yaml with %d entries at %s"
+                % (len(customize), out_path)
             )
         except Exception as err:
             self.error(f"Error writing customize.yaml: {err}")


### PR DESCRIPTION
## Summary
- write `customize.yaml` to the configuration directory
- fix look up of area names for each light so file contains entries
- ensure path resolution works if AppDaemon's config lives in its own folder
- improve log output when writing the file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688a86a1fad0832db77d4cd5b5108f01